### PR TITLE
Fix/xpcf2ilt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -56,14 +56,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.flywaydb</groupId>-->
-<!--            <artifactId>flyway-core</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.flywaydb</groupId>-->
-<!--            <artifactId>flyway-database-postgresql</artifactId>-->
-<!--        </dependency>-->
+        <!--        <dependency>-->
+        <!--            <groupId>org.flywaydb</groupId>-->
+        <!--            <artifactId>flyway-core</artifactId>-->
+        <!--        </dependency>-->
+        <!--        <dependency>-->
+        <!--            <groupId>org.flywaydb</groupId>-->
+        <!--            <artifactId>flyway-database-postgresql</artifactId>-->
+        <!--        </dependency>-->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.13</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/test/java/com/postech/fastfood/adapter/driven/persistence/repository/ProductRepositoryAdapterTest.java
+++ b/src/test/java/com/postech/fastfood/adapter/driven/persistence/repository/ProductRepositoryAdapterTest.java
@@ -11,14 +11,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.postech.fastfood.adapter.driven.persistence.repository.employee.IEmployeeEntityRepository;
-import com.postech.fastfood.adapter.driven.persistence.repository.product.IProductRepository;
-import com.postech.fastfood.adapter.driven.persistence.repository.product.ProductRepositoryAdapter;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import com.postech.fastfood.adapter.driven.persistence.entity.EmployeeEntity;
 import com.postech.fastfood.adapter.driven.persistence.entity.ProductEntity;
+import com.postech.fastfood.adapter.driven.persistence.repository.employee.IEmployeeEntityRepository;
+import com.postech.fastfood.adapter.driven.persistence.repository.product.IProductRepository;
+import com.postech.fastfood.adapter.driven.persistence.repository.product.ProductRepositoryAdapter;
 import com.postech.fastfood.application.mapper.EmployeeMapper;
 import com.postech.fastfood.application.mapper.ProductMapper;
 import com.postech.fastfood.core.domain.Employee;
@@ -166,6 +166,7 @@ class ProductRepositoryAdapterTest {
         // Arrange
         Long productId = 1L;
 
+        when(productRepository.findById(productId)).thenReturn(Optional.of(ProductEntity.builder().id(productId).build()));
         // Act
         adapter.delete(productId);
 

--- a/src/test/java/com/postech/fastfood/core/service/customer/FindCustomerByCpfUseCaseImplTest.java
+++ b/src/test/java/com/postech/fastfood/core/service/customer/FindCustomerByCpfUseCaseImplTest.java
@@ -1,24 +1,26 @@
 package com.postech.fastfood.core.service.customer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
 import com.postech.fastfood.core.domain.Customer;
 import com.postech.fastfood.core.domain.enums.UserRole;
-import com.postech.fastfood.core.ports.UserRepositoryPort;
+import com.postech.fastfood.core.ports.CustomerRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class FindCustomerByCpfUseCaseImplTest {
-
     @Mock
-    UserRepositoryPort userRepositoryPort;
+    CustomerRepositoryPort customerRepositoryPort;
 
     @InjectMocks
     FindCustomerByCpfUseCaseImpl useCase;
@@ -35,7 +37,7 @@ class FindCustomerByCpfUseCaseImplTest {
         cliente.setName("João");
         cliente.setRole(role);
 
-        when(userRepositoryPort.findByCpf(cpf, role)).thenReturn(cliente);
+        when(customerRepositoryPort.findByCpf(cpf)).thenReturn(cliente);
 
         // Act
         Customer resultado = (Customer) useCase.execute(cpf);
@@ -45,7 +47,7 @@ class FindCustomerByCpfUseCaseImplTest {
         assertEquals(cpf, resultado.getCpf());
         assertEquals("João", resultado.getName());
         assertEquals(UserRole.ROLE_CUSTOMER, resultado.getRole());
-        verify(userRepositoryPort, times(1)).findByCpf(cpf, role);
+        verify(customerRepositoryPort, times(1)).findByCpf(cpf);
     }
 
     @Test
@@ -54,13 +56,13 @@ class FindCustomerByCpfUseCaseImplTest {
         String cpf = "00000000000";
         UserRole role = UserRole.ROLE_CUSTOMER;
 
-        when(userRepositoryPort.findByCpf(cpf, role)).thenReturn(null);
+        when(customerRepositoryPort.findByCpf(cpf)).thenReturn(null);
 
         // Act
         var resultado = useCase.execute(cpf);
 
         // Assert
         assertNull(resultado);
-        verify(userRepositoryPort, times(1)).findByCpf(cpf, role);
+        verify(customerRepositoryPort, times(1)).findByCpf(cpf);
     }
 }

--- a/src/test/java/com/postech/fastfood/core/service/employee/CreateEmployeeUseCaseImplTest.java
+++ b/src/test/java/com/postech/fastfood/core/service/employee/CreateEmployeeUseCaseImplTest.java
@@ -1,5 +1,15 @@
 package com.postech.fastfood.core.service.employee;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.UUID;
 import com.postech.fastfood.core.domain.Employee;
 import com.postech.fastfood.core.domain.enums.UserRole;
 import com.postech.fastfood.core.exception.FastFoodException;
@@ -12,12 +22,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
-
-import java.sql.SQLException;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CreateEmployeeUseCaseImplTest {
@@ -85,7 +89,7 @@ class CreateEmployeeUseCaseImplTest {
                 () -> useCase.execute(employee)
         );
 
-        assertEquals("Email já cadastrado", exception.getMessage());
+        assertEquals("Email already exists", exception.getMessage());
     }
 
     @Test
@@ -103,6 +107,6 @@ class CreateEmployeeUseCaseImplTest {
                 () -> useCase.execute(employee)
         );
 
-        assertEquals("CPF já cadastrado", exception.getMessage());
+        assertEquals("CPF already exists", exception.getMessage());
     }
 }


### PR DESCRIPTION
🔧 Descrição da PR
Esta PR corrige falhas de build e de testes unitários na aplicação.

✅ Alterações realizadas
Atualização da versão do plugin JaCoCo de 0.8.2 para 0.8.13 para garantir compatibilidade com o JDK 17.

Correção de testes unitários:

CreateEmployeeUseCaseImplTest: ajuste nas mensagens esperadas.

FindCustomerByCpfUseCaseImplTest: correção de mocks e verificação de chamadas no customerRepositoryPort.

ProductRepositoryAdapterTest: mock do findById para evitar exceções durante o teste de deleção.

📦 Motivação
Essas alterações são necessárias para restaurar a estabilidade da build, garantir a execução correta dos testes e permitir integração contínua sem falhas.